### PR TITLE
feat: カスタム楽曲のスコア保存機能実装 #95

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "howler": "^2.2.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-firebase-hooks": "^5.1.1",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.30.1",
         "zustand": "^5.0.5"
@@ -3987,6 +3988,16 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-firebase-hooks": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-5.1.1.tgz",
+      "integrity": "sha512-y2UpWs82xs+39q5Rc/wq316ca52QsC0n8m801V+yM4IC4hbfOL4yQPVSh7w+ydstdvjN9F+lvs1WrO2VYxpmdA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "firebase": ">= 9.0.0",
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "howler": "^2.2.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-firebase-hooks": "^5.1.1",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.1",
     "zustand": "^5.0.5"

--- a/src/pages/PlayCustom.jsx
+++ b/src/pages/PlayCustom.jsx
@@ -55,11 +55,11 @@ export default function PlayCustom() {
       // 多少の誤差を許容
       soundRef.current.stop()
       nav('/result', {
-        state: { 
-          score: scoreRef.current, 
+        state: {
+          score: scoreRef.current,
           counts: countsRef.current,
           chartId,
-          chartTitle: chartDataRef.current?.title || '無題'
+          chartTitle: chartDataRef.current?.title || '無題',
         },
       })
     }
@@ -143,11 +143,11 @@ export default function PlayCustom() {
             setTimeout(
               () =>
                 nav('/result', {
-                  state: { 
-                    score: scoreRef.current, 
+                  state: {
+                    score: scoreRef.current,
                     counts: countsRef.current,
                     chartId,
-                    chartTitle: chartDataRef.current?.title || '無題'
+                    chartTitle: chartDataRef.current?.title || '無題',
                   },
                 }),
               500

--- a/src/pages/PlayCustom.jsx
+++ b/src/pages/PlayCustom.jsx
@@ -55,7 +55,12 @@ export default function PlayCustom() {
       // 多少の誤差を許容
       soundRef.current.stop()
       nav('/result', {
-        state: { score: scoreRef.current, counts: countsRef.current },
+        state: { 
+          score: scoreRef.current, 
+          counts: countsRef.current,
+          chartId,
+          chartTitle: chartDataRef.current?.title || '無題'
+        },
       })
     }
 
@@ -138,7 +143,12 @@ export default function PlayCustom() {
             setTimeout(
               () =>
                 nav('/result', {
-                  state: { score: scoreRef.current, counts: countsRef.current },
+                  state: { 
+                    score: scoreRef.current, 
+                    counts: countsRef.current,
+                    chartId,
+                    chartTitle: chartDataRef.current?.title || '無題'
+                  },
                 }),
               500
             )

--- a/src/pages/Result.jsx
+++ b/src/pages/Result.jsx
@@ -2,7 +2,11 @@ import { Link, useLocation } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import { useAuthState } from 'react-firebase-hooks/auth'
 import { auth } from '../firebase'
-import { saveCustomChartScore, calculateAccuracy, getTopScoreForChart } from '../utils/scoreManager'
+import {
+  saveCustomChartScore,
+  calculateAccuracy,
+  getTopScoreForChart,
+} from '../utils/scoreManager'
 
 export default function Result() {
   const { state } = useLocation()
@@ -62,7 +66,7 @@ export default function Result() {
 
       setRankingsLoading(true)
       const result = await getTopScoreForChart(state.chartId)
-      
+
       if (result.success) {
         setRankings(result.rankings)
       }
@@ -383,52 +387,65 @@ export default function Result() {
             <h3 className="text-lg font-bold text-center text-white mb-4">
               🏆 ランキング TOP3
             </h3>
-            
+
             {rankingsLoading && (
               <div className="text-center text-gray-400 text-sm">
                 ランキングを取得中...
               </div>
             )}
-            
+
             {!rankingsLoading && rankings.length > 0 && (
               <div className="space-y-3">
-                {rankings.map((ranking) => {
-                  const getRankEmoji = (rank) => {
-                    switch(rank) {
-                      case 1: return '🥇'
-                      case 2: return '🥈'
-                      case 3: return '🥉'
-                      default: return '🏅'
+                {rankings.map(ranking => {
+                  const getRankEmoji = rank => {
+                    switch (rank) {
+                      case 1:
+                        return '🥇'
+                      case 2:
+                        return '🥈'
+                      case 3:
+                        return '🥉'
+                      default:
+                        return '🏅'
                     }
                   }
-                  
-                  const getRankColor = (rank) => {
-                    switch(rank) {
-                      case 1: return 'text-yellow-400'
-                      case 2: return 'text-gray-300'
-                      case 3: return 'text-amber-600'
-                      default: return 'text-gray-400'
+
+                  const getRankColor = rank => {
+                    switch (rank) {
+                      case 1:
+                        return 'text-yellow-400'
+                      case 2:
+                        return 'text-gray-300'
+                      case 3:
+                        return 'text-amber-600'
+                      default:
+                        return 'text-gray-400'
                     }
                   }
-                  
+
                   return (
-                    <div 
-                      key={ranking.userId} 
+                    <div
+                      key={ranking.userId}
                       className="flex items-center justify-between p-3 bg-white/5 rounded-lg"
                     >
                       <div className="flex items-center gap-3">
-                        <span className="text-xl">{getRankEmoji(ranking.rank)}</span>
+                        <span className="text-xl">
+                          {getRankEmoji(ranking.rank)}
+                        </span>
                         <div>
                           <div className="font-semibold text-white">
                             {ranking.userName}
                           </div>
                           <div className="text-xs text-gray-400">
-                            Perfect: {ranking.perfect} | Good: {ranking.good} | Miss: {ranking.miss}
+                            Perfect: {ranking.perfect} | Good: {ranking.good} |
+                            Miss: {ranking.miss}
                           </div>
                         </div>
                       </div>
                       <div className="text-right">
-                        <div className={`text-xl font-bold ${getRankColor(ranking.rank)}`}>
+                        <div
+                          className={`text-xl font-bold ${getRankColor(ranking.rank)}`}
+                        >
                           {ranking.score.toLocaleString()}
                         </div>
                         <div className="text-xs text-gray-400">
@@ -440,7 +457,7 @@ export default function Result() {
                 })}
               </div>
             )}
-            
+
             {!rankingsLoading && rankings.length === 0 && (
               <div className="text-center text-gray-400 text-sm">
                 まだ記録がありません

--- a/src/pages/Result.jsx
+++ b/src/pages/Result.jsx
@@ -24,14 +24,14 @@ export default function Result() {
       if (!state?.chartId || !user || !state?.counts) return
 
       setSaveStatus('saving')
-      
+
       const accuracy = calculateAccuracy(state.counts)
       const scoreData = {
         score: state.score || 0,
         perfect: state.counts.perfect || 0,
         good: state.counts.good || 0,
         miss: state.counts.miss || 0,
-        accuracy
+        accuracy,
       }
 
       const result = await saveCustomChartScore(
@@ -342,19 +342,13 @@ export default function Result() {
         {state?.chartId && (
           <div className="text-center mb-6">
             {saveStatus === 'saving' && (
-              <div className="text-yellow-400 text-sm">
-                スコアを保存中...
-              </div>
+              <div className="text-yellow-400 text-sm">スコアを保存中...</div>
             )}
             {saveStatus === 'success' && (
-              <div className="text-green-400 text-sm">
-                ✅ {saveMessage}
-              </div>
+              <div className="text-green-400 text-sm">✅ {saveMessage}</div>
             )}
             {saveStatus === 'error' && (
-              <div className="text-red-400 text-sm">
-                ❌ {saveMessage}
-              </div>
+              <div className="text-red-400 text-sm">❌ {saveMessage}</div>
             )}
             {!user && (
               <div className="text-gray-400 text-sm">

--- a/src/pages/Result.jsx
+++ b/src/pages/Result.jsx
@@ -2,7 +2,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import { useAuthState } from 'react-firebase-hooks/auth'
 import { auth } from '../firebase'
-import { saveCustomChartScore, calculateAccuracy } from '../utils/scoreManager'
+import { saveCustomChartScore, calculateAccuracy, getTopScoreForChart } from '../utils/scoreManager'
 
 export default function Result() {
   const { state } = useLocation()
@@ -10,6 +10,8 @@ export default function Result() {
   const [user] = useAuthState(auth)
   const [saveStatus, setSaveStatus] = useState(null) // null | 'saving' | 'success' | 'error'
   const [saveMessage, setSaveMessage] = useState('')
+  const [rankings, setRankings] = useState([])
+  const [rankingsLoading, setRankingsLoading] = useState(false)
 
   useEffect(() => {
     // 少し遅延させてから結果を表示
@@ -52,6 +54,23 @@ export default function Result() {
 
     saveScore()
   }, [state, user])
+
+  // カスタム楽曲のランキング取得
+  useEffect(() => {
+    const fetchRankings = async () => {
+      if (!state?.chartId) return
+
+      setRankingsLoading(true)
+      const result = await getTopScoreForChart(state.chartId)
+      
+      if (result.success) {
+        setRankings(result.rankings)
+      }
+      setRankingsLoading(false)
+    }
+
+    fetchRankings()
+  }, [state?.chartId])
 
   // マルチプレイ用の結果表示
   if (state && state.isMultiPlayer) {
@@ -353,6 +372,78 @@ export default function Result() {
             {!user && (
               <div className="text-gray-400 text-sm">
                 ログインするとスコアが保存されます
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ランキング情報（カスタム楽曲の場合のみ） */}
+        {state?.chartId && (
+          <div className="mb-6 p-4 bg-white/5 rounded-lg border border-white/10">
+            <h3 className="text-lg font-bold text-center text-white mb-4">
+              🏆 ランキング TOP3
+            </h3>
+            
+            {rankingsLoading && (
+              <div className="text-center text-gray-400 text-sm">
+                ランキングを取得中...
+              </div>
+            )}
+            
+            {!rankingsLoading && rankings.length > 0 && (
+              <div className="space-y-3">
+                {rankings.map((ranking) => {
+                  const getRankEmoji = (rank) => {
+                    switch(rank) {
+                      case 1: return '🥇'
+                      case 2: return '🥈'
+                      case 3: return '🥉'
+                      default: return '🏅'
+                    }
+                  }
+                  
+                  const getRankColor = (rank) => {
+                    switch(rank) {
+                      case 1: return 'text-yellow-400'
+                      case 2: return 'text-gray-300'
+                      case 3: return 'text-amber-600'
+                      default: return 'text-gray-400'
+                    }
+                  }
+                  
+                  return (
+                    <div 
+                      key={ranking.userId} 
+                      className="flex items-center justify-between p-3 bg-white/5 rounded-lg"
+                    >
+                      <div className="flex items-center gap-3">
+                        <span className="text-xl">{getRankEmoji(ranking.rank)}</span>
+                        <div>
+                          <div className="font-semibold text-white">
+                            {ranking.userName}
+                          </div>
+                          <div className="text-xs text-gray-400">
+                            Perfect: {ranking.perfect} | Good: {ranking.good} | Miss: {ranking.miss}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <div className={`text-xl font-bold ${getRankColor(ranking.rank)}`}>
+                          {ranking.score.toLocaleString()}
+                        </div>
+                        <div className="text-xs text-gray-400">
+                          精度: {ranking.accuracy}%
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+            
+            {!rankingsLoading && rankings.length === 0 && (
+              <div className="text-center text-gray-400 text-sm">
+                まだ記録がありません
               </div>
             )}
           </div>

--- a/src/utils/scoreManager.js
+++ b/src/utils/scoreManager.js
@@ -1,0 +1,74 @@
+import { doc, setDoc, getDoc, serverTimestamp } from 'firebase/firestore'
+import { db } from '../firebase'
+
+/**
+ * カスタム楽曲のスコアをFirestoreに保存する
+ * @param {string} chartId - 楽曲ID
+ * @param {string} userId - ユーザーID  
+ * @param {string} userName - ユーザー名
+ * @param {Object} scoreData - スコアデータ
+ * @param {number} scoreData.score - 総スコア
+ * @param {number} scoreData.perfect - Perfect数
+ * @param {number} scoreData.good - Good数
+ * @param {number} scoreData.miss - Miss数
+ * @param {number} scoreData.accuracy - 精度（%）
+ * @returns {Promise<{success: boolean, isNewRecord: boolean, message: string}>}
+ */
+export async function saveCustomChartScore(chartId, userId, userName, scoreData) {
+  try {
+    const rankingDocRef = doc(db, 'charts', chartId, 'rankings', userId)
+    
+    // 既存スコアを確認
+    const existingDoc = await getDoc(rankingDocRef)
+    const existingScore = existingDoc.exists() ? existingDoc.data().score : 0
+    
+    // 新しいスコアが既存スコアより高い場合のみ保存
+    if (scoreData.score > existingScore) {
+      await setDoc(rankingDocRef, {
+        score: scoreData.score,
+        perfect: scoreData.perfect,
+        good: scoreData.good,
+        miss: scoreData.miss,
+        accuracy: scoreData.accuracy,
+        userName: userName,
+        timestamp: serverTimestamp(),
+        updatedAt: serverTimestamp()
+      })
+      
+      return {
+        success: true,
+        isNewRecord: true,
+        message: existingDoc.exists() 
+          ? `新記録！ ${existingScore} → ${scoreData.score}` 
+          : '初回記録を保存しました！'
+      }
+    } else {
+      return {
+        success: true,
+        isNewRecord: false,
+        message: `現在の最高記録: ${existingScore} （今回: ${scoreData.score}）`
+      }
+    }
+  } catch (error) {
+    console.error('スコア保存エラー:', error)
+    return {
+      success: false,
+      isNewRecord: false,
+      message: 'スコアの保存に失敗しました'
+    }
+  }
+}
+
+/**
+ * 精度を計算する
+ * @param {Object} counts - 判定回数
+ * @param {number} counts.perfect - Perfect数
+ * @param {number} counts.good - Good数  
+ * @param {number} counts.miss - Miss数
+ * @returns {number} 精度（%、小数点第1位まで）
+ */
+export function calculateAccuracy(counts) {
+  const total = counts.perfect + counts.good + counts.miss
+  if (total === 0) return 0
+  return Math.round(((counts.perfect + counts.good * 0.5) / total) * 1000) / 10
+}

--- a/src/utils/scoreManager.js
+++ b/src/utils/scoreManager.js
@@ -4,7 +4,7 @@ import { db } from '../firebase'
 /**
  * カスタム楽曲のスコアをFirestoreに保存する
  * @param {string} chartId - 楽曲ID
- * @param {string} userId - ユーザーID  
+ * @param {string} userId - ユーザーID
  * @param {string} userName - ユーザー名
  * @param {Object} scoreData - スコアデータ
  * @param {number} scoreData.score - 総スコア
@@ -14,14 +14,19 @@ import { db } from '../firebase'
  * @param {number} scoreData.accuracy - 精度（%）
  * @returns {Promise<{success: boolean, isNewRecord: boolean, message: string}>}
  */
-export async function saveCustomChartScore(chartId, userId, userName, scoreData) {
+export async function saveCustomChartScore(
+  chartId,
+  userId,
+  userName,
+  scoreData
+) {
   try {
     const rankingDocRef = doc(db, 'charts', chartId, 'rankings', userId)
-    
+
     // 既存スコアを確認
     const existingDoc = await getDoc(rankingDocRef)
     const existingScore = existingDoc.exists() ? existingDoc.data().score : 0
-    
+
     // 新しいスコアが既存スコアより高い場合のみ保存
     if (scoreData.score > existingScore) {
       await setDoc(rankingDocRef, {
@@ -32,21 +37,21 @@ export async function saveCustomChartScore(chartId, userId, userName, scoreData)
         accuracy: scoreData.accuracy,
         userName: userName,
         timestamp: serverTimestamp(),
-        updatedAt: serverTimestamp()
+        updatedAt: serverTimestamp(),
       })
-      
+
       return {
         success: true,
         isNewRecord: true,
-        message: existingDoc.exists() 
-          ? `新記録！ ${existingScore} → ${scoreData.score}` 
-          : '初回記録を保存しました！'
+        message: existingDoc.exists()
+          ? `新記録！ ${existingScore} → ${scoreData.score}`
+          : '初回記録を保存しました！',
       }
     } else {
       return {
         success: true,
         isNewRecord: false,
-        message: `現在の最高記録: ${existingScore} （今回: ${scoreData.score}）`
+        message: `現在の最高記録: ${existingScore} （今回: ${scoreData.score}）`,
       }
     }
   } catch (error) {
@@ -54,7 +59,7 @@ export async function saveCustomChartScore(chartId, userId, userName, scoreData)
     return {
       success: false,
       isNewRecord: false,
-      message: 'スコアの保存に失敗しました'
+      message: 'スコアの保存に失敗しました',
     }
   }
 }
@@ -63,7 +68,7 @@ export async function saveCustomChartScore(chartId, userId, userName, scoreData)
  * 精度を計算する
  * @param {Object} counts - 判定回数
  * @param {number} counts.perfect - Perfect数
- * @param {number} counts.good - Good数  
+ * @param {number} counts.good - Good数
  * @param {number} counts.miss - Miss数
  * @returns {number} 精度（%、小数点第1位まで）
  */

--- a/src/utils/scoreManager.js
+++ b/src/utils/scoreManager.js
@@ -1,4 +1,14 @@
-import { doc, setDoc, getDoc, serverTimestamp, collection, query, orderBy, limit, getDocs } from 'firebase/firestore'
+import {
+  doc,
+  setDoc,
+  getDoc,
+  serverTimestamp,
+  collection,
+  query,
+  orderBy,
+  limit,
+  getDocs,
+} from 'firebase/firestore'
 import { db } from '../firebase'
 
 /**
@@ -88,15 +98,15 @@ export async function getTopScoreForChart(chartId) {
     const rankingsRef = collection(db, 'charts', chartId, 'rankings')
     const q = query(rankingsRef, orderBy('score', 'desc'), limit(3))
     const querySnapshot = await getDocs(q)
-    
+
     if (querySnapshot.empty) {
       return {
         success: true,
         rankings: [],
-        message: 'まだスコアが記録されていません'
+        message: 'まだスコアが記録されていません',
       }
     }
-    
+
     const rankings = querySnapshot.docs.map((doc, index) => {
       const data = doc.data()
       return {
@@ -108,21 +118,21 @@ export async function getTopScoreForChart(chartId) {
         good: data.good,
         miss: data.miss,
         accuracy: data.accuracy,
-        timestamp: data.timestamp
+        timestamp: data.timestamp,
       }
     })
-    
+
     return {
       success: true,
       rankings: rankings,
-      message: 'ランキング取得成功'
+      message: 'ランキング取得成功',
     }
   } catch (error) {
     console.error('ランキング取得エラー:', error)
     return {
       success: false,
       rankings: [],
-      message: 'ランキングの取得に失敗しました'
+      message: 'ランキングの取得に失敗しました',
     }
   }
 }


### PR DESCRIPTION
## 概要
issue #95 の実装：カスタム楽曲のスコアをFirestoreに保存する機能を追加
issue #96 の実装：ランキングの表示

## 実装内容

### 🎯 主な変更
- **PlayCustomページ**: Result渡し時にchartIdとchartTitleを追加
- **Resultページ**: Firebase認証とスコア保存機能を追加
- **スコア保存ユーティリティ**: 新規作成（`src/utils/scoreManager.js`）

### 📊 データ構造
```
charts/{chartId}/rankings/{userId}: {
  score: number,
  perfect: number,
  good: number,
  miss: number,
  accuracy: number,
  userName: string,
  timestamp: Timestamp,
  updatedAt: Timestamp
}
```

### 🔧 技術詳細
- Firebase Firestoreでスコア保存
- 既存スコアより高い場合のみ更新
- リアルタイム保存状況表示
- 認証状態に応じた適切なUX

### 🎮 動作フロー
1. カスタム楽曲をプレイ
2. 結果画面で認証状態確認
3. ログイン済みなら自動でスコア保存
4. 新記録の場合は保存、そうでなければスキップ
5. 保存結果をユーザーに表示

### 📦 追加依存関係
- `react-firebase-hooks`: Firebase認証フック用

## テスト
- カスタム楽曲でのプレイ→結果画面でスコア保存確認
- 新記録・既存記録以下での動作確認
- 未ログイン時の適切なメッセージ表示確認

## 関連Issue
Closes #95
Closes #96 

